### PR TITLE
Change URL for the API docs

### DIFF
--- a/src/docs/projects/index.md
+++ b/src/docs/projects/index.md
@@ -16,7 +16,7 @@ Features:
 - WebSocket feed for services that want to receive live database updates.
 - High rate limit (see API docs)
 
-API documentation can be found [here](https://api.sinking.yachts/docs).
+API documentation can be found [here](https://phish.sinking.yachts/docs).
 
 
 


### PR DESCRIPTION
The old URL is not working, this PR changes it to the new one